### PR TITLE
Added Ratings API with GET and tests

### DIFF
--- a/fhrs/establishments.go
+++ b/fhrs/establishments.go
@@ -28,22 +28,6 @@ type Geocode struct {
 	Latitude  string `json:"latitude"`
 }
 
-type Meta struct {
-	DataSource  string    `json:"dataSource"`
-	ExtractDate Timestamp `json:"extractDate"`
-	ItemCount   int       `json:"itemCount"`
-	Returncode  string    `json:"returncode"`
-	TotalCount  int       `json:"totalCount"`
-	TotalPages  int       `json:"totalPages"`
-	PageSize    int       `json:"pageSize"`
-	PageNumber  int       `json:"pageNumber"`
-}
-
-type Link struct {
-	Rel  string `json:"rel"`
-	Href string `json:"href"`
-}
-
 type Establishment struct {
 	FHRSID                     int       `json:"FHRSID"`
 	LocalAuthorityBusinessID   string    `json:"LocalAuthorityBusinessID"`

--- a/fhrs/establishments_test.go
+++ b/fhrs/establishments_test.go
@@ -232,7 +232,7 @@ func TestGetByID_Headers(t *testing.T) {
 		io.WriteString(w, body)
 	})
 
-	if err := client.SetLanguage(Cymraeg); err != nil {
+	if err := client.SetLanguage(LanguageCymraeg); err != nil {
 		t.Error(err)
 	}
 

--- a/fhrs/fhrs_test.go
+++ b/fhrs/fhrs_test.go
@@ -44,7 +44,7 @@ func TestNewClient(t *testing.T) {
 		t.Error(err)
 	}
 
-	if c.language != English {
+	if c.language != LanguageEnglish {
 		t.Error("Expected default language to be English")
 	}
 }
@@ -55,12 +55,12 @@ func TestSetLanguage(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = c.SetLanguage(English)
+	err = c.SetLanguage(LanguageEnglish)
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = c.SetLanguage(Cymraeg)
+	err = c.SetLanguage(LanguageCymraeg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,8 +76,8 @@ func TestAPILanguageString(t *testing.T) {
 		want string
 		have string
 	}{
-		{want: "en-GB", have: English.String()},
-		{want: "cy-GB", have: Cymraeg.String()},
+		{want: "en-GB", have: LanguageEnglish.String()},
+		{want: "cy-GB", have: LanguageCymraeg.String()},
 	}
 
 	for _, c := range cases {

--- a/fhrs/ratings.go
+++ b/fhrs/ratings.go
@@ -1,0 +1,35 @@
+package fhrs
+
+// RatingsService encapsulates the Ratings methods of the API.
+//
+// https://api.ratings.food.gov.uk/help#Ratings
+type RatingsService service
+
+// Ratings is the list of possible ratings.
+type Ratings struct {
+	Ratings []Rating `json:"ratings"`
+	Meta    Meta     `json:"meta"`
+	Links   []Link   `json:"links"`
+}
+
+// Rating is a possible hygiene rating value.
+type Rating struct {
+	RatingID      int    `json:"ratingId"`
+	RatingName    string `json:"ratingName"`
+	RatingKey     string `json:"ratingKey"`
+	RatingKeyName string `json:"ratingKeyName"`
+	SchemeTypeID  int    `json:"schemeTypeId"`
+	Links         []Link `json:"links"`
+}
+
+// Get returns the details of all possible ratings.
+//
+// https://api.ratings.food.gov.uk/Help/Api/GET-Ratings
+func (s *RatingsService) Get() (*Ratings, error) {
+	var ratings *Ratings
+	if err := s.client.get("Ratings", &ratings); err != nil {
+		return nil, err
+	}
+
+	return ratings, nil
+}

--- a/fhrs/ratings_test.go
+++ b/fhrs/ratings_test.go
@@ -1,0 +1,170 @@
+package fhrs
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestGet(t *testing.T) {
+	client, server, router, err := getTestEnv()
+	if err != nil {
+		t.Error(err)
+	}
+
+	server.Start()
+	defer server.Close()
+
+	body := `{
+	  "ratings": [
+		{
+		  "ratingId": 12,
+		  "ratingName": "5",
+		  "ratingKey": "fhrs_5_en-gb",
+		  "ratingKeyName": "5",
+		  "schemeTypeId": 1,
+		  "links": [
+			{
+			  "rel": "self",
+			  "href": "http://api.ratings.food.gov.uk/ratings/12"
+			}
+		  ]
+		},
+		{
+		  "ratingId": 11,
+		  "ratingName": "4",
+		  "ratingKey": "fhrs_4_en-gb",
+		  "ratingKeyName": "4",
+		  "schemeTypeId": 1,
+		  "links": [
+			{
+			  "rel": "self",
+			  "href": "http://api.ratings.food.gov.uk/ratings/11"
+			}
+		  ]
+		}
+	  ],
+	  "meta": {
+		"dataSource": "API",
+		"extractDate": "2020-02-03T22:32:34.2688747+00:00",
+		"itemCount": 11,
+		"returncode": "OK",
+		"totalCount": 11,
+		"totalPages": 1,
+		"pageSize": 11,
+		"pageNumber": 1
+	  },
+	  "links": [
+		{
+		  "rel": "self",
+		  "href": "http://api.ratings.food.gov.uk/ratings"
+		}
+	  ]
+	}`
+
+	ed, _ := time.Parse(time.RFC3339Nano, "2020-02-03T22:32:34.2688747+00:00")
+
+	expected := &Ratings{
+		Ratings: []Rating{
+			{
+				RatingID:      12,
+				RatingName:    "5",
+				RatingKey:     "fhrs_5_en-gb",
+				RatingKeyName: "5",
+				SchemeTypeID:  1,
+				Links: []Link{
+					{
+						Rel:  "self",
+						Href: "http://api.ratings.food.gov.uk/ratings/12",
+					},
+				},
+			},
+			{
+				RatingID:      11,
+				RatingName:    "4",
+				RatingKey:     "fhrs_4_en-gb",
+				RatingKeyName: "4",
+				SchemeTypeID:  1,
+				Links: []Link{
+					{
+						Rel:  "self",
+						Href: "http://api.ratings.food.gov.uk/ratings/11",
+					},
+				},
+			},
+		},
+		Meta: Meta{
+			DataSource:  "API",
+			ExtractDate: Timestamp(ed),
+			ItemCount:   11,
+			Returncode:  "OK",
+			TotalCount:  11,
+			TotalPages:  1,
+			PageSize:    11,
+			PageNumber:  1,
+		},
+		Links: []Link{
+			{
+				Rel:  "self",
+				Href: "http://api.ratings.food.gov.uk/ratings",
+			},
+		},
+	}
+
+	router.GET("/Ratings", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, body)
+	})
+
+	actual, err := client.Ratings.Get()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if actual == nil {
+		t.Error("Expected response but got nil")
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected:\n%+v\nBut got:\n%+v\n", expected, actual)
+	}
+}
+
+func TestGet_Error(t *testing.T) {
+	client, server, router, err := getTestEnv()
+	if err != nil {
+		t.Error(err)
+	}
+
+	server.Start()
+	defer server.Close()
+
+	errorMsg := "The service is unavailable."
+
+	router.GET("/Ratings", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		io.WriteString(w, errorMsg)
+	})
+
+	_, err = client.Ratings.Get()
+	if err == nil {
+		t.Error("Expected an error to be returned but got nil")
+	}
+
+	apiErr, ok := err.(APIError)
+	if !ok {
+		t.Error("Expected error to be an APIError")
+	}
+
+	if apiErr.Message != errorMsg {
+		t.Errorf("Expected message to be %s but got %s", errorMsg, apiErr.Message)
+	}
+
+	if apiErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("Expected status code to be %d but got %d", http.StatusServiceUnavailable, apiErr.StatusCode)
+	}
+}


### PR DESCRIPTION
## Changes

* Added Ratings API with `GET /Ratings`.
* Handle non `application/json` responses, for example plain text/html from servers.
* Moved `Link` and `Meta` structs to `fhrs.go` as they are common to multiple services.
* Changed language constants to be prefixed with `Language`
* Additional comments on models.
* `gofmt`